### PR TITLE
refactor: codebase cleanup and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,15 @@
+# Build output
 /gh-pr-review
 /gh-pr-review.exe
+/dist/
+
+# Test
+*.out
+coverage.txt
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,9 +4,11 @@ linters:
   default: none
   enable:
     - errcheck
+    - errorlint
     - govet
     - ineffassign
     - staticcheck
     - unused
     - gocritic
     - misspell
+    - nolintlint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,9 @@ go test -v ./internal/github/
 # Run a single test
 go test -v -run TestParse_SingleHunk ./internal/diff/
 
+# Lint
+golangci-lint run ./...
+
 # Vet
 go vet ./...
 
@@ -36,9 +39,17 @@ This is a GitHub CLI extension (`gh pr-review <PR number>`) built with Go and th
 ### Package structure
 
 - **`main.go`** — Entry point. Parses args, detects repo via `go-gh`, initializes API client, starts Bubble Tea program.
-- **`internal/github/`** — GitHub API layer. `Client` wraps both GraphQL (`go-gh` `api.GraphQLClient`) and REST (`api.RESTClient`). All queries/mutations are raw strings in `queries.go`. Types are in `types.go`. Pagination is handled internally (100 items per page).
+- **`internal/github/`** — GitHub API layer. `Client` wraps both GraphQL (`go-gh` `api.GraphQLClient`) and REST (`api.RESTClient`). All queries/mutations are raw strings in `queries.go`. Types (including `DiffSide`, `ViewedState`, `ReviewEvent`) are in `types.go`. Pagination is handled internally (100 items per page).
 - **`internal/diff/`** — Pure diff parsing. `Parse()` converts a unified diff patch string into `[]DiffLine` with tracked old/new line numbers. `RenderLine()` produces colored terminal output.
-- **`internal/tui/`** — Bubble Tea TUI. The main `Model` in `model.go` orchestrates everything. `FileListModel` (left pane) and `DiffViewModel` (right pane) are sub-components. Input modes: NORMAL → COMMENT/REPLY/REVIEW.
+- **`internal/tui/`** — Bubble Tea TUI split across files:
+  - `model.go` — Model definition, Init, Update, key handlers
+  - `view.go` — All View/render methods
+  - `commands.go` — Async tea.Cmd functions, data update helpers, layout helpers
+  - `filelist.go` — Left pane: file list with viewed state
+  - `diffview.go` — Right pane: scrollable diff with inline threads
+  - `keymap.go` — Key bindings
+  - `styles.go` — lipgloss styles
+  - `messages.go` — Async message types
 
 ### Data flow
 
@@ -47,11 +58,10 @@ This is a GitHub CLI extension (`gh pr-review <PR number>`) built with Go and th
 3. Both use `bool` flags (`patchesFetched`/`threadsFetched`) to track completion — **not nil checks** (a nil slice from zero results vs "not yet fetched" must be distinguished)
 4. On ready, `DiffViewModel` renders parsed diff lines with inline review threads mapped by line number
 
-### Key bindings are defined in `keymap.go`, styles in `styles.go`, async message types in `messages.go`.
-
 ## Conventions
 
 - GraphQL queries use `client.gql.Do()` with raw query strings, not the shurcooL struct-tag approach
 - API error messages are in Japanese (matches the user's locale)
+- `DiffSide` is a typed constant (`gh.DiffSideLeft`/`gh.DiffSideRight`), not a raw string
 - `DiffViewModel.buildDisplayRows()` maps diff lines + thread comments into flat `displayRow` slices for rendering; thread comments have `diffLineIdx = -1`
-- `matchesThread()` uses `DiffSide` (LEFT/RIGHT) to match threads to old vs new line numbers
+- `matchesThread()` uses `DiffSide` to match threads to old vs new line numbers

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ gh pr-review <PR number>
 
 - [GitHub CLI](https://cli.github.com/) (`gh`) v2.0+
 - Authenticated via `gh auth login`
+- Must be run from inside a git repository that has a GitHub remote
 
 ## Development
 
@@ -75,7 +76,10 @@ gh pr-review <PR number>
 go build -o gh-pr-review .
 
 # Test
-go test ./...
+go test -race ./...
+
+# Lint
+golangci-lint run ./...
 
 # Install locally
 gh extension install .

--- a/internal/diff/parser.go
+++ b/internal/diff/parser.go
@@ -101,13 +101,14 @@ func parseHunkHeader(line string) (oldStart, newStart int) {
 	for _, r := range rangeParts {
 		if strings.HasPrefix(r, "-") {
 			nums := strings.SplitN(r[1:], ",", 2)
-			oldStart, _ = strconv.Atoi(nums[0])
+			oldStart, _ = strconv.Atoi(nums[0]) // falls back to 0 on parse error
 		} else if strings.HasPrefix(r, "+") {
 			nums := strings.SplitN(r[1:], ",", 2)
-			newStart, _ = strconv.Atoi(nums[0])
+			newStart, _ = strconv.Atoi(nums[0]) // falls back to 0 on parse error
 		}
 	}
 
+	// Default to 1 for new/deleted files where the hunk header shows 0
 	if oldStart == 0 {
 		oldStart = 1
 	}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -177,7 +177,6 @@ func (c *Client) FetchReviewThreads(number int) ([]ReviewThread, error) {
 							IsResolved bool
 							Path       string
 							Line       int
-							StartLine  int
 							DiffSide   string
 							Comments   struct {
 								Nodes []struct {
@@ -204,15 +203,14 @@ func (c *Client) FetchReviewThreads(number int) ([]ReviewThread, error) {
 				IsResolved: t.IsResolved,
 				Path:       t.Path,
 				Line:       t.Line,
-				StartLine:  t.StartLine,
-				DiffSide:   t.DiffSide,
+				DiffSide:   DiffSide(t.DiffSide),
 			}
-			for _, c := range t.Comments.Nodes {
+			for _, comment := range t.Comments.Nodes {
 				thread.Comments = append(thread.Comments, ReviewComment{
-					ID:        c.ID,
-					Body:      c.Body,
-					Author:    c.Author.Login,
-					CreatedAt: c.CreatedAt,
+					ID:        comment.ID,
+					Body:      comment.Body,
+					Author:    comment.Author.Login,
+					CreatedAt: comment.CreatedAt,
 				})
 			}
 			allThreads = append(allThreads, thread)
@@ -228,13 +226,13 @@ func (c *Client) FetchReviewThreads(number int) ([]ReviewThread, error) {
 	return allThreads, nil
 }
 
-func (c *Client) AddComment(pullRequestID, path, body, side string, line int) error {
+func (c *Client) AddComment(pullRequestID, path, body string, side DiffSide, line int) error {
 	variables := map[string]interface{}{
 		"pullRequestId": pullRequestID,
 		"body":          body,
 		"path":          path,
 		"line":          line,
-		"side":          side,
+		"side":          string(side),
 	}
 	var resp interface{}
 	return c.gql.Do(addReviewCommentMutation, variables, &resp)

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -11,8 +12,14 @@ func TestViewedState_Constants(t *testing.T) {
 	if ViewedStateUnviewed != "UNVIEWED" {
 		t.Errorf("ViewedStateUnviewed = %q, want %q", ViewedStateUnviewed, "UNVIEWED")
 	}
-	if ViewedStateDismissed != "DISMISSED" {
-		t.Errorf("ViewedStateDismissed = %q, want %q", ViewedStateDismissed, "DISMISSED")
+}
+
+func TestDiffSide_Constants(t *testing.T) {
+	if DiffSideLeft != "LEFT" {
+		t.Errorf("DiffSideLeft = %q, want %q", DiffSideLeft, "LEFT")
+	}
+	if DiffSideRight != "RIGHT" {
+		t.Errorf("DiffSideRight = %q, want %q", DiffSideRight, "RIGHT")
 	}
 }
 
@@ -59,8 +66,7 @@ func TestReviewThread_Fields(t *testing.T) {
 		IsResolved: false,
 		Path:       "main.go",
 		Line:       10,
-		StartLine:  8,
-		DiffSide:   "RIGHT",
+		DiffSide:   DiffSideRight,
 		Comments: []ReviewComment{
 			{ID: "C_1", Body: "Fix this", Author: "alice", CreatedAt: "2026-01-01T00:00:00Z"},
 			{ID: "C_2", Body: "Done", Author: "bob", CreatedAt: "2026-01-01T01:00:00Z"},
@@ -134,23 +140,10 @@ func TestGraphQLQueryStrings_ContainExpectedFields(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for _, field := range tt.expected {
-				if !containsString(tt.query, field) {
+				if !strings.Contains(tt.query, field) {
 					t.Errorf("query %s should contain %q", tt.name, field)
 				}
 			}
 		})
 	}
-}
-
-func containsString(s, substr string) bool {
-	return len(s) >= len(substr) && searchString(s, substr)
-}
-
-func searchString(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/github/queries.go
+++ b/internal/github/queries.go
@@ -60,7 +60,6 @@ query($owner: String!, $repo: String!, $number: Int!, $after: String) {
           isResolved
           path
           line
-          startLine
           diffSide
           comments(first: 100) {
             nodes {

--- a/internal/github/types.go
+++ b/internal/github/types.go
@@ -5,7 +5,13 @@ type ViewedState string
 const (
 	ViewedStateViewed   ViewedState = "VIEWED"
 	ViewedStateUnviewed ViewedState = "UNVIEWED"
-	ViewedStateDismissed ViewedState = "DISMISSED"
+)
+
+type DiffSide string
+
+const (
+	DiffSideLeft  DiffSide = "LEFT"
+	DiffSideRight DiffSide = "RIGHT"
 )
 
 type PRFile struct {
@@ -38,8 +44,7 @@ type ReviewThread struct {
 	IsResolved bool
 	Path       string
 	Line       int
-	StartLine  int
-	DiffSide   string
+	DiffSide   DiffSide
 	Comments   []ReviewComment
 }
 

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -1,0 +1,224 @@
+package tui
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/yukikotani231/gh-pr-review/internal/diff"
+	gh "github.com/yukikotani231/gh-pr-review/internal/github"
+)
+
+func (m Model) fetchPRCmd() tea.Cmd {
+	return func() tea.Msg {
+		pr, err := m.client.FetchPR(m.prNumber)
+		return PRFetchedMsg{PR: pr, Err: err}
+	}
+}
+
+func (m Model) fetchDiffsCmd() tea.Cmd {
+	return func() tea.Msg {
+		patches, err := m.client.FetchDiffs(m.prNumber)
+		return DiffFetchedMsg{Patches: patches, Err: err}
+	}
+}
+
+func (m Model) fetchThreadsCmd() tea.Cmd {
+	return func() tea.Msg {
+		threads, err := m.client.FetchReviewThreads(m.prNumber)
+		return ThreadsFetchedMsg{Threads: threads, Err: err}
+	}
+}
+
+func (m Model) toggleViewedCmd() tea.Cmd {
+	f := m.fileList.SelectedFile()
+	if f == nil {
+		return nil
+	}
+	path := f.Path
+	currentState := f.ViewerViewedState
+	prID := m.pr.ID
+
+	return func() tea.Msg {
+		var newState gh.ViewedState
+		var err error
+		if currentState == gh.ViewedStateViewed {
+			err = m.client.UnmarkFileAsViewed(prID, path)
+			newState = gh.ViewedStateUnviewed
+		} else {
+			err = m.client.MarkFileAsViewed(prID, path)
+			newState = gh.ViewedStateViewed
+		}
+		return ViewedToggledMsg{Path: path, NewState: newState, Err: err}
+	}
+}
+
+func (m Model) addCommentCmd(body string) tea.Cmd {
+	dl := m.diffView.CursorLine()
+	if dl == nil {
+		return nil
+	}
+	f := m.fileList.SelectedFile()
+	if f == nil {
+		return nil
+	}
+	path := f.Path
+	prID := m.pr.ID
+
+	var side gh.DiffSide
+	var line int
+	if dl.Type == diff.LineRemoved {
+		side = gh.DiffSideLeft
+		line = dl.OldLineNum
+	} else {
+		side = gh.DiffSideRight
+		line = dl.NewLineNum
+	}
+
+	return func() tea.Msg {
+		err := m.client.AddComment(prID, path, body, side, line)
+		return CommentAddedMsg{Err: err}
+	}
+}
+
+func (m Model) replyToThreadCmd(threadID, body string) tea.Cmd {
+	return func() tea.Msg {
+		err := m.client.ReplyToThread(threadID, body)
+		return ThreadRepliedMsg{Err: err}
+	}
+}
+
+func (m Model) toggleResolveCmd(t *gh.ReviewThread) tea.Cmd {
+	threadID := t.ID
+	isResolved := t.IsResolved
+	return func() tea.Msg {
+		var err error
+		if isResolved {
+			err = m.client.UnresolveThread(threadID)
+		} else {
+			err = m.client.ResolveThread(threadID)
+		}
+		return ThreadResolvedMsg{
+			ThreadID:   threadID,
+			IsResolved: !isResolved,
+			Err:        err,
+		}
+	}
+}
+
+func (m Model) submitReviewCmd(event gh.ReviewEvent, body string) tea.Cmd {
+	prID := m.pr.ID
+	return func() tea.Msg {
+		err := m.client.SubmitReview(prID, event, body)
+		return ReviewSubmittedMsg{Event: event, Err: err}
+	}
+}
+
+func (m Model) refreshDataCmd() tea.Cmd {
+	return func() tea.Msg {
+		pr, err := m.client.FetchPR(m.prNumber)
+		if err != nil {
+			return DataRefreshedMsg{Err: err}
+		}
+		patches, err := m.client.FetchDiffs(m.prNumber)
+		if err != nil {
+			return DataRefreshedMsg{Err: err}
+		}
+		threads, err := m.client.FetchReviewThreads(m.prNumber)
+		if err != nil {
+			return DataRefreshedMsg{Err: err}
+		}
+		return DataRefreshedMsg{PR: pr, Patches: patches, Threads: threads}
+	}
+}
+
+// --- Data update helpers ---
+
+func (m *Model) updateLayout() {
+	leftWidth := m.leftPaneWidth()
+	contentHeight := m.contentHeight()
+	m.fileList.SetSize(leftWidth-2, contentHeight)
+	rightWidth := m.rightPaneWidth()
+	m.diffView.SetSize(rightWidth-4, contentHeight-1) // -1 for file path line
+	m.textInput.SetWidth(m.width - 4)
+	if m.state == stateReady {
+		m.updateDiffView()
+	}
+}
+
+func (m *Model) updateDiffView() {
+	f := m.fileList.SelectedFile()
+	if f == nil {
+		m.diffView.SetContent(nil, nil)
+		return
+	}
+	patch := m.patches[f.Path]
+	lines := diff.Parse(patch)
+	fileThreads := m.threadsForFile(f.Path)
+	m.diffView.SetContent(lines, fileThreads)
+}
+
+func (m *Model) threadsForFile(path string) []gh.ReviewThread {
+	var result []gh.ReviewThread
+	for _, t := range m.threads {
+		if t.Path == path {
+			result = append(result, t)
+		}
+	}
+	return result
+}
+
+func (m *Model) findThreadAtCursor() *gh.ReviewThread {
+	dl := m.diffView.CursorLine()
+	if dl == nil {
+		return nil
+	}
+	f := m.fileList.SelectedFile()
+	if f == nil {
+		return nil
+	}
+	for i, t := range m.diffView.threads {
+		if matchesThread(*dl, t) {
+			m.diffView.threadCursor = i
+			return &m.diffView.threads[i]
+		}
+	}
+	return nil
+}
+
+func (m Model) unresolvedThreadCount() int {
+	count := 0
+	for _, t := range m.threads {
+		if !t.IsResolved {
+			count++
+		}
+	}
+	return count
+}
+
+// --- Layout helpers ---
+
+func (m Model) leftPaneWidth() int {
+	w := m.width * 30 / 100
+	if w < 20 {
+		w = 20
+	}
+	return w
+}
+
+func (m Model) rightPaneWidth() int {
+	return m.width - m.leftPaneWidth()
+}
+
+func (m Model) contentHeight() int {
+	overhead := 3 // header(1) + status(1) + margin(1)
+	switch m.mode {
+	case modeComment, modeReply:
+		overhead = 6 // header(1) + input area(~5)
+	case modeReview:
+		overhead = 14 // header(1) + review modal(~13)
+	}
+	h := m.height - overhead
+	if h < 5 {
+		h = 5
+	}
+	return h
+}

--- a/internal/tui/diffview.go
+++ b/internal/tui/diffview.go
@@ -162,7 +162,7 @@ func (m *DiffViewModel) PrevThread() {
 }
 
 func matchesThread(dl diff.DiffLine, t gh.ReviewThread) bool {
-	if t.DiffSide == "LEFT" {
+	if t.DiffSide == gh.DiffSideLeft {
 		return dl.OldLineNum == t.Line
 	}
 	return dl.NewLineNum == t.Line

--- a/internal/tui/diffview_test.go
+++ b/internal/tui/diffview_test.go
@@ -24,7 +24,7 @@ func testThreads() []gh.ReviewThread {
 			IsResolved: false,
 			Path:       "test.go",
 			Line:       2, // matches new line2 (NewLineNum=2)
-			DiffSide:   "RIGHT",
+			DiffSide:   gh.DiffSideRight,
 			Comments: []gh.ReviewComment{
 				{ID: "c1", Body: "Fix this", Author: "alice", CreatedAt: "2026-02-24T10:00:00Z"},
 			},
@@ -34,7 +34,7 @@ func testThreads() []gh.ReviewThread {
 			IsResolved: true,
 			Path:       "test.go",
 			Line:       5, // matches line5 (NewLineNum=5)
-			DiffSide:   "RIGHT",
+			DiffSide:   gh.DiffSideRight,
 			Comments: []gh.ReviewComment{
 				{ID: "c2", Body: "LGTM", Author: "bob", CreatedAt: "2026-02-24T09:00:00Z"},
 				{ID: "c3", Body: "Thanks!", Author: "alice", CreatedAt: "2026-02-24T09:30:00Z"},
@@ -335,37 +335,37 @@ func TestMatchesThread(t *testing.T) {
 		{
 			name:     "RIGHT side matches NewLineNum",
 			dl:       diff.DiffLine{NewLineNum: 10, OldLineNum: 8},
-			thread:   gh.ReviewThread{Line: 10, DiffSide: "RIGHT"},
+			thread:   gh.ReviewThread{Line: 10, DiffSide: gh.DiffSideRight},
 			expected: true,
 		},
 		{
 			name:     "RIGHT side no match",
 			dl:       diff.DiffLine{NewLineNum: 10, OldLineNum: 8},
-			thread:   gh.ReviewThread{Line: 8, DiffSide: "RIGHT"},
+			thread:   gh.ReviewThread{Line: 8, DiffSide: gh.DiffSideRight},
 			expected: false,
 		},
 		{
 			name:     "LEFT side matches OldLineNum",
 			dl:       diff.DiffLine{NewLineNum: 10, OldLineNum: 8},
-			thread:   gh.ReviewThread{Line: 8, DiffSide: "LEFT"},
+			thread:   gh.ReviewThread{Line: 8, DiffSide: gh.DiffSideLeft},
 			expected: true,
 		},
 		{
 			name:     "LEFT side no match",
 			dl:       diff.DiffLine{NewLineNum: 10, OldLineNum: 8},
-			thread:   gh.ReviewThread{Line: 10, DiffSide: "LEFT"},
+			thread:   gh.ReviewThread{Line: 10, DiffSide: gh.DiffSideLeft},
 			expected: false,
 		},
 		{
 			name:     "added line with RIGHT thread",
 			dl:       diff.DiffLine{NewLineNum: 5, OldLineNum: 0, Type: diff.LineAdded},
-			thread:   gh.ReviewThread{Line: 5, DiffSide: "RIGHT"},
+			thread:   gh.ReviewThread{Line: 5, DiffSide: gh.DiffSideRight},
 			expected: true,
 		},
 		{
 			name:     "removed line with LEFT thread",
 			dl:       diff.DiffLine{NewLineNum: 0, OldLineNum: 3, Type: diff.LineRemoved},
-			thread:   gh.ReviewThread{Line: 3, DiffSide: "LEFT"},
+			thread:   gh.ReviewThread{Line: 3, DiffSide: gh.DiffSideLeft},
 			expected: true,
 		},
 	}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -8,7 +8,6 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/textarea"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 
 	"github.com/yukikotani231/gh-pr-review/internal/diff"
 	gh "github.com/yukikotani231/gh-pr-review/internal/github"
@@ -45,7 +44,7 @@ type Model struct {
 	pr       *gh.PullRequest
 	prNumber int
 	patches  map[string]string
-	threads  []gh.ReviewThread // all threads for this PR
+	threads  []gh.ReviewThread
 
 	fileList FileListModel
 	diffView DiffViewModel
@@ -56,14 +55,15 @@ type Model struct {
 	height int
 	focus  pane
 
-	// Data fetch tracking
+	// Data fetch tracking (use bool flags, not nil checks, to distinguish
+	// "not yet fetched" from "fetched but zero results")
 	patchesFetched bool
 	threadsFetched bool
 
 	// Input mode state
 	mode          inputMode
 	textInput     textarea.Model
-	replyThreadID string // thread ID when replying
+	replyThreadID string
 
 	// Review submission state
 	reviewCursor int // 0=approve, 1=request changes, 2=comment
@@ -81,15 +81,15 @@ func NewModel(client *gh.Client, prNumber int) Model {
 	ta.SetHeight(3)
 
 	return Model{
-		state:    stateLoading,
-		client:   client,
-		prNumber: prNumber,
-		help:     h,
-		keyMap:   DefaultKeyMap(),
-		focus:    leftPane,
-		diffView: NewDiffViewModel(),
+		state:     stateLoading,
+		client:    client,
+		prNumber:  prNumber,
+		help:      h,
+		keyMap:    DefaultKeyMap(),
+		focus:     leftPane,
+		diffView:  NewDiffViewModel(),
 		textInput: ta,
-		mode:     modeNormal,
+		mode:      modeNormal,
 	}
 }
 
@@ -204,7 +204,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.pr = msg.PR
 		m.patches = msg.Patches
 		m.threads = msg.Threads
-		// Re-sync file list viewed states
 		m.fileList.SetFiles(msg.PR.Files)
 		m.updateDiffView()
 		return m, nil
@@ -214,7 +213,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	// Handle input modes first
 	switch m.mode {
 	case modeComment, modeReply:
 		return m.handleInputKey(msg)
@@ -222,7 +220,6 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleReviewKey(msg)
 	}
 
-	// Normal mode
 	switch {
 	case key.Matches(msg, m.keyMap.Quit):
 		return m, tea.Quit
@@ -253,7 +250,6 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	// Pane-specific keys
 	if m.focus == leftPane {
 		return m.handleLeftPaneKey(msg)
 	}
@@ -300,7 +296,6 @@ func (m *Model) handleRightPaneKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case key.Matches(msg, m.keyMap.Reply):
 		t := m.diffView.CursorThread()
 		if t == nil {
-			// Try to find a thread at the current cursor line
 			t = m.findThreadAtCursor()
 		}
 		if t == nil {
@@ -350,11 +345,9 @@ func (m *Model) handleInputKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.mode == modeComment {
 			return m, m.addCommentCmd(body)
 		}
-		// modeReply
 		return m, m.replyToThreadCmd(m.replyThreadID, body)
 	}
 
-	// Forward to textarea
 	var cmd tea.Cmd
 	m.textInput, cmd = m.textInput.Update(msg)
 	return m, cmd
@@ -387,7 +380,6 @@ func (m *Model) handleReviewKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case "tab":
-		// Switch focus to/from textarea
 		if m.textInput.Focused() {
 			m.textInput.Blur()
 		} else {
@@ -396,7 +388,6 @@ func (m *Model) handleReviewKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	// If textarea is focused, forward input
 	if m.textInput.Focused() {
 		var cmd tea.Cmd
 		m.textInput, cmd = m.textInput.Update(msg)
@@ -404,363 +395,4 @@ func (m *Model) handleReviewKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	return m, nil
-}
-
-// View renders the entire UI
-func (m Model) View() string {
-	if m.state == stateLoading {
-		return fmt.Sprintf("\n  Loading PR #%d...\n", m.prNumber)
-	}
-	if m.state == stateError {
-		return fmt.Sprintf("\n  Error: %v\n\n  Press q to quit.\n", m.err)
-	}
-
-	header := m.renderHeader()
-	content := m.renderContent()
-
-	var bottom string
-	switch m.mode {
-	case modeComment, modeReply:
-		bottom = m.renderInputArea()
-	case modeReview:
-		bottom = m.renderReviewModal()
-	default:
-		bottom = m.renderStatusBar()
-	}
-
-	return lipgloss.JoinVertical(lipgloss.Left, header, content, bottom)
-}
-
-func (m Model) renderHeader() string {
-	progress := fmt.Sprintf("%d/%d viewed",
-		m.fileList.ViewedCount(), len(m.pr.Files))
-
-	threadCount := m.unresolvedThreadCount()
-	var threadInfo string
-	if threadCount > 0 {
-		threadInfo = fmt.Sprintf(", %d unresolved", threadCount)
-	}
-
-	title := fmt.Sprintf(" PR #%d: %s  (+%d -%d, %d files, %s%s)",
-		m.pr.Number, m.pr.Title,
-		m.pr.Additions, m.pr.Deletions,
-		m.pr.ChangedFiles, progress, threadInfo)
-
-	return headerStyle.Width(m.width).Render(title)
-}
-
-func (m Model) renderContent() string {
-	leftWidth := m.leftPaneWidth()
-	rightWidth := m.rightPaneWidth()
-	contentHeight := m.contentHeight()
-
-	var leftBorder, rightBorder lipgloss.Style
-	if m.focus == leftPane {
-		leftBorder = focusedBorderStyle.Width(leftWidth - 2).Height(contentHeight)
-		rightBorder = unfocusedBorderStyle.Width(rightWidth - 2).Height(contentHeight)
-	} else {
-		leftBorder = unfocusedBorderStyle.Width(leftWidth - 2).Height(contentHeight)
-		rightBorder = focusedBorderStyle.Width(rightWidth - 2).Height(contentHeight)
-	}
-
-	left := leftBorder.Render(m.fileList.View())
-
-	// Show file path above diff
-	var diffContent string
-	if f := m.fileList.SelectedFile(); f != nil {
-		pathLine := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("6")).Render(f.Path)
-		diffContent = pathLine + "\n" + m.diffView.View()
-	} else {
-		diffContent = m.diffView.View()
-	}
-	right := rightBorder.Render(diffContent)
-
-	return lipgloss.JoinHorizontal(lipgloss.Top, left, right)
-}
-
-func (m Model) renderStatusBar() string {
-	var helpBindings []key.Binding
-	if m.focus == leftPane {
-		helpBindings = []key.Binding{m.keyMap.Up, m.keyMap.Down, m.keyMap.ToggleViewed, m.keyMap.Tab, m.keyMap.SubmitReview, m.keyMap.Quit}
-	} else {
-		helpBindings = []key.Binding{m.keyMap.Up, m.keyMap.Down, m.keyMap.Comment, m.keyMap.Reply, m.keyMap.Resolve, m.keyMap.NextThread, m.keyMap.ToggleViewed, m.keyMap.SubmitReview, m.keyMap.Tab, m.keyMap.Quit}
-	}
-	helpView := m.help.ShortHelpView(helpBindings)
-
-	status := helpView
-	if m.statusMsg != "" {
-		status = m.statusMsg + "  " + helpView
-	}
-
-	if f := m.fileList.SelectedFile(); f != nil {
-		fileInfo := lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Render(f.Path)
-		gap := strings.Repeat(" ", max(1, m.width-lipgloss.Width(status)-lipgloss.Width(fileInfo)-2))
-		status = fileInfo + gap + status
-	}
-
-	return statusBarStyle.Width(m.width).Render(status)
-}
-
-func (m Model) renderInputArea() string {
-	var label string
-	if m.mode == modeComment {
-		label = inputLabelStyle.Render(" New comment (Ctrl+s: submit, Esc: cancel)")
-	} else {
-		label = inputLabelStyle.Render(" Reply (Ctrl+s: submit, Esc: cancel)")
-	}
-	return lipgloss.JoinVertical(lipgloss.Left,
-		label,
-		m.textInput.View(),
-	)
-}
-
-func (m Model) renderReviewModal() string {
-	events := []struct {
-		label string
-		event gh.ReviewEvent
-	}{
-		{"Approve", gh.ReviewEventApprove},
-		{"Request Changes", gh.ReviewEventRequestChanges},
-		{"Comment", gh.ReviewEventComment},
-	}
-
-	var sb strings.Builder
-	sb.WriteString(inputLabelStyle.Render("Submit Review") + "\n\n")
-
-	for i, e := range events {
-		prefix := "  "
-		style := reviewOptionStyle
-		if i == m.reviewCursor {
-			prefix = "> "
-			style = reviewSelectedStyle
-		}
-		sb.WriteString(style.Render(fmt.Sprintf("%s%s", prefix, e.label)))
-		sb.WriteString("\n")
-	}
-
-	sb.WriteString("\n")
-	sb.WriteString(m.textInput.View())
-	sb.WriteString("\n")
-	sb.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Render(
-		"  ↑↓: select  Tab: edit body  Ctrl+s: submit  Esc: cancel"))
-
-	return reviewModalStyle.Width(m.width - 4).Render(sb.String())
-}
-
-// --- Data update helpers ---
-
-func (m *Model) updateLayout() {
-	leftWidth := m.leftPaneWidth()
-	contentHeight := m.contentHeight()
-	m.fileList.SetSize(leftWidth-2, contentHeight)
-	rightWidth := m.rightPaneWidth()
-	m.diffView.SetSize(rightWidth-4, contentHeight-1) // -1 for file path line
-	m.textInput.SetWidth(m.width - 4)
-	if m.state == stateReady {
-		m.updateDiffView()
-	}
-}
-
-func (m *Model) updateDiffView() {
-	f := m.fileList.SelectedFile()
-	if f == nil {
-		m.diffView.SetContent(nil, nil)
-		return
-	}
-	patch := m.patches[f.Path]
-	lines := diff.Parse(patch)
-	fileThreads := m.threadsForFile(f.Path)
-	m.diffView.SetContent(lines, fileThreads)
-}
-
-func (m *Model) threadsForFile(path string) []gh.ReviewThread {
-	var result []gh.ReviewThread
-	for _, t := range m.threads {
-		if t.Path == path {
-			result = append(result, t)
-		}
-	}
-	return result
-}
-
-func (m *Model) findThreadAtCursor() *gh.ReviewThread {
-	dl := m.diffView.CursorLine()
-	if dl == nil {
-		return nil
-	}
-	f := m.fileList.SelectedFile()
-	if f == nil {
-		return nil
-	}
-	for i, t := range m.diffView.threads {
-		if matchesThread(*dl, t) {
-			m.diffView.threadCursor = i
-			return &m.diffView.threads[i]
-		}
-	}
-	return nil
-}
-
-func (m Model) unresolvedThreadCount() int {
-	count := 0
-	for _, t := range m.threads {
-		if !t.IsResolved {
-			count++
-		}
-	}
-	return count
-}
-
-// --- Commands ---
-
-func (m Model) fetchPRCmd() tea.Cmd {
-	return func() tea.Msg {
-		pr, err := m.client.FetchPR(m.prNumber)
-		return PRFetchedMsg{PR: pr, Err: err}
-	}
-}
-
-func (m Model) fetchDiffsCmd() tea.Cmd {
-	return func() tea.Msg {
-		patches, err := m.client.FetchDiffs(m.prNumber)
-		return DiffFetchedMsg{Patches: patches, Err: err}
-	}
-}
-
-func (m Model) fetchThreadsCmd() tea.Cmd {
-	return func() tea.Msg {
-		threads, err := m.client.FetchReviewThreads(m.prNumber)
-		return ThreadsFetchedMsg{Threads: threads, Err: err}
-	}
-}
-
-func (m Model) toggleViewedCmd() tea.Cmd {
-	f := m.fileList.SelectedFile()
-	if f == nil {
-		return nil
-	}
-	path := f.Path
-	currentState := f.ViewerViewedState
-	prID := m.pr.ID
-
-	return func() tea.Msg {
-		var newState gh.ViewedState
-		var err error
-		if currentState == gh.ViewedStateViewed {
-			err = m.client.UnmarkFileAsViewed(prID, path)
-			newState = gh.ViewedStateUnviewed
-		} else {
-			err = m.client.MarkFileAsViewed(prID, path)
-			newState = gh.ViewedStateViewed
-		}
-		return ViewedToggledMsg{Path: path, NewState: newState, Err: err}
-	}
-}
-
-func (m Model) addCommentCmd(body string) tea.Cmd {
-	dl := m.diffView.CursorLine()
-	if dl == nil {
-		return nil
-	}
-	f := m.fileList.SelectedFile()
-	if f == nil {
-		return nil
-	}
-	path := f.Path
-	prID := m.pr.ID
-
-	var side string
-	var line int
-	if dl.Type == diff.LineRemoved {
-		side = "LEFT"
-		line = dl.OldLineNum
-	} else {
-		side = "RIGHT"
-		line = dl.NewLineNum
-	}
-
-	return func() tea.Msg {
-		err := m.client.AddComment(prID, path, body, side, line)
-		return CommentAddedMsg{Err: err}
-	}
-}
-
-func (m Model) replyToThreadCmd(threadID, body string) tea.Cmd {
-	return func() tea.Msg {
-		err := m.client.ReplyToThread(threadID, body)
-		return ThreadRepliedMsg{Err: err}
-	}
-}
-
-func (m Model) toggleResolveCmd(t *gh.ReviewThread) tea.Cmd {
-	threadID := t.ID
-	isResolved := t.IsResolved
-	return func() tea.Msg {
-		var err error
-		if isResolved {
-			err = m.client.UnresolveThread(threadID)
-		} else {
-			err = m.client.ResolveThread(threadID)
-		}
-		return ThreadResolvedMsg{
-			ThreadID:   threadID,
-			IsResolved: !isResolved,
-			Err:        err,
-		}
-	}
-}
-
-func (m Model) submitReviewCmd(event gh.ReviewEvent, body string) tea.Cmd {
-	prID := m.pr.ID
-	return func() tea.Msg {
-		err := m.client.SubmitReview(prID, event, body)
-		return ReviewSubmittedMsg{Event: event, Err: err}
-	}
-}
-
-func (m Model) refreshDataCmd() tea.Cmd {
-	return func() tea.Msg {
-		pr, err := m.client.FetchPR(m.prNumber)
-		if err != nil {
-			return DataRefreshedMsg{Err: err}
-		}
-		patches, err := m.client.FetchDiffs(m.prNumber)
-		if err != nil {
-			return DataRefreshedMsg{Err: err}
-		}
-		threads, err := m.client.FetchReviewThreads(m.prNumber)
-		if err != nil {
-			return DataRefreshedMsg{Err: err}
-		}
-		return DataRefreshedMsg{PR: pr, Patches: patches, Threads: threads}
-	}
-}
-
-// --- Layout helpers ---
-
-func (m Model) leftPaneWidth() int {
-	w := m.width * 30 / 100
-	if w < 20 {
-		w = 20
-	}
-	return w
-}
-
-func (m Model) rightPaneWidth() int {
-	return m.width - m.leftPaneWidth()
-}
-
-func (m Model) contentHeight() int {
-	overhead := 3 // header(1) + status(1) + margin(1)
-	switch m.mode {
-	case modeComment, modeReply:
-		overhead = 6 // header(1) + input area(~5)
-	case modeReview:
-		overhead = 14 // header(1) + review modal(~13)
-	}
-	h := m.height - overhead
-	if h < 5 {
-		h = 5
-	}
-	return h
 }

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -1,0 +1,151 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/lipgloss"
+
+	gh "github.com/yukikotani231/gh-pr-review/internal/github"
+)
+
+// View renders the entire UI.
+func (m Model) View() string {
+	if m.state == stateLoading {
+		return fmt.Sprintf("\n  Loading PR #%d...\n", m.prNumber)
+	}
+	if m.state == stateError {
+		return fmt.Sprintf("\n  Error: %v\n\n  Press q to quit.\n", m.err)
+	}
+
+	header := m.renderHeader()
+	content := m.renderContent()
+
+	var bottom string
+	switch m.mode {
+	case modeComment, modeReply:
+		bottom = m.renderInputArea()
+	case modeReview:
+		bottom = m.renderReviewModal()
+	default:
+		bottom = m.renderStatusBar()
+	}
+
+	return lipgloss.JoinVertical(lipgloss.Left, header, content, bottom)
+}
+
+func (m Model) renderHeader() string {
+	progress := fmt.Sprintf("%d/%d viewed",
+		m.fileList.ViewedCount(), len(m.pr.Files))
+
+	threadCount := m.unresolvedThreadCount()
+	var threadInfo string
+	if threadCount > 0 {
+		threadInfo = fmt.Sprintf(", %d unresolved", threadCount)
+	}
+
+	title := fmt.Sprintf(" PR #%d: %s  (+%d -%d, %d files, %s%s)",
+		m.pr.Number, m.pr.Title,
+		m.pr.Additions, m.pr.Deletions,
+		m.pr.ChangedFiles, progress, threadInfo)
+
+	return headerStyle.Width(m.width).Render(title)
+}
+
+func (m Model) renderContent() string {
+	leftWidth := m.leftPaneWidth()
+	rightWidth := m.rightPaneWidth()
+	contentHeight := m.contentHeight()
+
+	var leftBorder, rightBorder lipgloss.Style
+	if m.focus == leftPane {
+		leftBorder = focusedBorderStyle.Width(leftWidth - 2).Height(contentHeight)
+		rightBorder = unfocusedBorderStyle.Width(rightWidth - 2).Height(contentHeight)
+	} else {
+		leftBorder = unfocusedBorderStyle.Width(leftWidth - 2).Height(contentHeight)
+		rightBorder = focusedBorderStyle.Width(rightWidth - 2).Height(contentHeight)
+	}
+
+	left := leftBorder.Render(m.fileList.View())
+
+	var diffContent string
+	if f := m.fileList.SelectedFile(); f != nil {
+		pathLine := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("6")).Render(f.Path)
+		diffContent = pathLine + "\n" + m.diffView.View()
+	} else {
+		diffContent = m.diffView.View()
+	}
+	right := rightBorder.Render(diffContent)
+
+	return lipgloss.JoinHorizontal(lipgloss.Top, left, right)
+}
+
+func (m Model) renderStatusBar() string {
+	var helpBindings []key.Binding
+	if m.focus == leftPane {
+		helpBindings = []key.Binding{m.keyMap.Up, m.keyMap.Down, m.keyMap.ToggleViewed, m.keyMap.Tab, m.keyMap.SubmitReview, m.keyMap.Quit}
+	} else {
+		helpBindings = []key.Binding{m.keyMap.Up, m.keyMap.Down, m.keyMap.Comment, m.keyMap.Reply, m.keyMap.Resolve, m.keyMap.NextThread, m.keyMap.ToggleViewed, m.keyMap.SubmitReview, m.keyMap.Tab, m.keyMap.Quit}
+	}
+	helpView := m.help.ShortHelpView(helpBindings)
+
+	status := helpView
+	if m.statusMsg != "" {
+		status = m.statusMsg + "  " + helpView
+	}
+
+	if f := m.fileList.SelectedFile(); f != nil {
+		fileInfo := lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Render(f.Path)
+		gap := strings.Repeat(" ", max(1, m.width-lipgloss.Width(status)-lipgloss.Width(fileInfo)-2))
+		status = fileInfo + gap + status
+	}
+
+	return statusBarStyle.Width(m.width).Render(status)
+}
+
+func (m Model) renderInputArea() string {
+	var label string
+	if m.mode == modeComment {
+		label = inputLabelStyle.Render(" New comment (Ctrl+s: submit, Esc: cancel)")
+	} else {
+		label = inputLabelStyle.Render(" Reply (Ctrl+s: submit, Esc: cancel)")
+	}
+	return lipgloss.JoinVertical(lipgloss.Left,
+		label,
+		m.textInput.View(),
+	)
+}
+
+func (m Model) renderReviewModal() string {
+	events := []struct {
+		label string
+		event gh.ReviewEvent
+	}{
+		{"Approve", gh.ReviewEventApprove},
+		{"Request Changes", gh.ReviewEventRequestChanges},
+		{"Comment", gh.ReviewEventComment},
+	}
+
+	var sb strings.Builder
+	sb.WriteString(inputLabelStyle.Render("Submit Review") + "\n\n")
+
+	for i, e := range events {
+		prefix := "  "
+		style := reviewOptionStyle
+		if i == m.reviewCursor {
+			prefix = "> "
+			style = reviewSelectedStyle
+		}
+		sb.WriteString(style.Render(fmt.Sprintf("%s%s", prefix, e.label)))
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString("\n")
+	sb.WriteString(m.textInput.View())
+	sb.WriteString("\n")
+	sb.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Render(
+		"  ↑↓: select  Tab: edit body  Ctrl+s: submit  Esc: cancel"))
+
+	return reviewModalStyle.Width(m.width - 4).Render(sb.String())
+}


### PR DESCRIPTION
## Summary
- Dead code 削除: `ViewedStateDismissed` 定数、`ReviewThread.StartLine` フィールド、GraphQL の `startLine` フィールド
- `DiffSide` を型付き定数に変更（`"LEFT"`/`"RIGHT"` 文字列リテラル → `gh.DiffSideLeft`/`gh.DiffSideRight`）
- `model.go`（766行）を `model.go` + `view.go` + `commands.go` に3分割
- 変数名改善（`c` → `comment`）、カスタム `containsString` → `strings.Contains`
- `.gitignore` 拡充（IDE、カバレッジ、dist 等）
- golangci-lint に `errorlint`、`nolintlint` を追加
- CLAUDE.md / README.md を実態に合わせて更新

## Test plan
- [x] `go build ./...` 成功
- [x] `go test -race -count=1 ./...` 全テストパス
- [x] `go vet ./...` パス
- [x] `golangci-lint run ./...` 0 issues
- [ ] CI の test / lint ジョブが両方グリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)