### PR TITLE
fix: skip shared split rows when moving cursor

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Summary
+
+- 
+
+## Verification
+
+- [ ] `go test ./...`
+- [ ] `go vet ./...`
+- [ ] `go build ./...`
+
+## TUI Checks
+
+- [ ] Not a TUI change
+- [ ] `go run . --fixture basic`
+- [ ] Run the fixture(s) relevant to this change
+- [ ] `COLUMNS=140 go run . --fixture wide-split` for split-diff-related changes
+
+## Notes
+
+- If this PR touches diff rendering, cursor movement, or inline threads, add or update regression tests.

--- a/internal/tui/diffview.go
+++ b/internal/tui/diffview.go
@@ -170,18 +170,12 @@ func (m *DiffViewModel) CursorThread() *gh.ReviewThread {
 
 func (m *DiffViewModel) MoveUp() {
 	m.threadCursor = -1
-	if m.cursor > 0 {
-		m.cursor--
-		m.ensureVisible()
-	}
+	m.moveCursorByDisplayRows(-1)
 }
 
 func (m *DiffViewModel) MoveDown() {
 	m.threadCursor = -1
-	if m.cursor < len(m.diffLines)-1 {
-		m.cursor++
-		m.ensureVisible()
-	}
+	m.moveCursorByDisplayRows(1)
 }
 
 func (m *DiffViewModel) HalfPageUp() {
@@ -302,6 +296,40 @@ func (m *DiffViewModel) ensureVisible() {
 	} else if row >= m.scrollY+m.height {
 		m.scrollY = row - m.height + 1
 	}
+}
+
+func (m *DiffViewModel) moveCursorByDisplayRows(delta int) {
+	if len(m.diffLines) == 0 || delta == 0 {
+		return
+	}
+
+	next := m.cursor + delta
+	if next < 0 {
+		next = 0
+	} else if next >= len(m.diffLines) {
+		next = len(m.diffLines) - 1
+	}
+
+	currentRow, hasCurrentRow := m.lineToFirstRow[m.cursor]
+	for next > 0 && next < len(m.diffLines)-1 {
+		nextRow, ok := m.lineToFirstRow[next]
+		if !ok {
+			break
+		}
+		if !hasCurrentRow || nextRow != currentRow {
+			break
+		}
+		next += delta
+	}
+
+	if next < 0 {
+		next = 0
+	} else if next >= len(m.diffLines) {
+		next = len(m.diffLines) - 1
+	}
+
+	m.cursor = next
+	m.ensureVisible()
 }
 
 func (m *DiffViewModel) ScrollUp() {

--- a/internal/tui/diffview.go
+++ b/internal/tui/diffview.go
@@ -302,33 +302,41 @@ func (m *DiffViewModel) moveCursorByDisplayRows(delta int) {
 	if len(m.diffLines) == 0 || delta == 0 {
 		return
 	}
-
-	next := m.cursor + delta
-	if next < 0 {
-		next = 0
-	} else if next >= len(m.diffLines) {
-		next = len(m.diffLines) - 1
+	currentRow, ok := m.lineToFirstRow[m.cursor]
+	if !ok {
+		m.cursor = max(0, min(m.cursor+delta, len(m.diffLines)-1))
+		m.ensureVisible()
+		return
 	}
 
-	currentRow, hasCurrentRow := m.lineToFirstRow[m.cursor]
-	for next > 0 && next < len(m.diffLines)-1 {
-		nextRow, ok := m.lineToFirstRow[next]
-		if !ok {
-			break
+	targetIdx := m.cursor
+	if delta > 0 {
+		nextRow := currentRow
+		for i := 0; i < len(m.diffLines); i++ {
+			row, ok := m.lineToFirstRow[i]
+			if !ok || row <= currentRow {
+				continue
+			}
+			if nextRow == currentRow || row < nextRow {
+				nextRow = row
+				targetIdx = i
+			}
 		}
-		if !hasCurrentRow || nextRow != currentRow {
-			break
+	} else {
+		prevRow := -1
+		for i := 0; i < len(m.diffLines); i++ {
+			row, ok := m.lineToFirstRow[i]
+			if !ok || row >= currentRow {
+				continue
+			}
+			if row > prevRow {
+				prevRow = row
+				targetIdx = i
+			}
 		}
-		next += delta
 	}
 
-	if next < 0 {
-		next = 0
-	} else if next >= len(m.diffLines) {
-		next = len(m.diffLines) - 1
-	}
-
-	m.cursor = next
+	m.cursor = targetIdx
 	m.ensureVisible()
 }
 

--- a/internal/tui/diffview_test.go
+++ b/internal/tui/diffview_test.go
@@ -821,3 +821,92 @@ func TestDiffView_ViewDoesNotAccumulateRowsAcrossRenders(t *testing.T) {
 		t.Fatalf("second render duplicated trailing line: %q", second)
 	}
 }
+
+func TestDiffView_DisplayRowInvariants_Unified(t *testing.T) {
+	m := NewDiffViewModel()
+	m.SetSize(80, 20)
+	m.SetContent(testDiffLines(), testThreads())
+
+	assertDisplayRowInvariants(t, &m)
+}
+
+func TestDiffView_DisplayRowInvariants_Split(t *testing.T) {
+	fixturePath := filepath.Join("..", "..", "testdata", "fixtures", "wide-split.json")
+	fixture, err := gh.LoadFixtureData(fixturePath)
+	if err != nil {
+		t.Fatalf("LoadFixtureData: %v", err)
+	}
+
+	lines := diff.Parse(fixture.DiffResult.Patches["internal/tui/split_layout.go"])
+	m := NewDiffViewModel()
+	m.SetSize(120, 40)
+	m.SetContent(lines, nil)
+	m.SetMode("split")
+
+	assertDisplayRowInvariants(t, &m)
+}
+
+func TestDiffView_SplitNavigationVisitsEachSharedRowOnce(t *testing.T) {
+	fixturePath := filepath.Join("..", "..", "testdata", "fixtures", "wide-split.json")
+	fixture, err := gh.LoadFixtureData(fixturePath)
+	if err != nil {
+		t.Fatalf("LoadFixtureData: %v", err)
+	}
+
+	lines := diff.Parse(fixture.DiffResult.Patches["internal/tui/split_layout.go"])
+	m := NewDiffViewModel()
+	m.SetSize(120, 40)
+	m.SetContent(lines, nil)
+	m.SetMode("split")
+
+	visited := map[int]int{}
+	for {
+		row := m.lineToFirstRow[m.cursor]
+		visited[row]++
+		if m.cursor == len(m.diffLines)-1 {
+			break
+		}
+		prev := m.cursor
+		m.MoveDown()
+		if m.cursor == prev {
+			t.Fatalf("cursor got stuck at %d", m.cursor)
+		}
+	}
+
+	for row, count := range visited {
+		if count > 1 {
+			t.Fatalf("display row %d visited %d times during linear navigation", row, count)
+		}
+	}
+}
+
+func assertDisplayRowInvariants(t *testing.T, m *DiffViewModel) {
+	t.Helper()
+
+	m.buildDisplayRows()
+
+	if len(m.lineToFirstRow) != len(m.diffLines) {
+		t.Fatalf("lineToFirstRow len = %d, want %d", len(m.lineToFirstRow), len(m.diffLines))
+	}
+
+	for i := range m.diffLines {
+		row, ok := m.lineToFirstRow[i]
+		if !ok {
+			t.Fatalf("missing lineToFirstRow entry for diff line %d", i)
+		}
+		if row < 0 || row >= len(m.displayRows) {
+			t.Fatalf("lineToFirstRow[%d] = %d out of range", i, row)
+		}
+	}
+
+	beforeRows := len(m.displayRows)
+	m.rebuildDisplayRows()
+	afterRows := len(m.displayRows)
+	if afterRows != beforeRows {
+		t.Fatalf("displayRows len changed across rebuild: %d -> %d", beforeRows, afterRows)
+	}
+
+	if m.cursor < 0 || m.cursor >= len(m.diffLines) {
+		t.Fatalf("cursor = %d out of range", m.cursor)
+	}
+}

--- a/internal/tui/diffview_test.go
+++ b/internal/tui/diffview_test.go
@@ -485,6 +485,32 @@ func TestDiffView_SplitAlignsMultipleRemovedAndAddedRows(t *testing.T) {
 	}
 }
 
+func TestDiffView_SplitMoveDownSkipsSharedDisplayRow(t *testing.T) {
+	m := NewDiffViewModel()
+	m.SetSize(80, 20)
+	m.SetContent(testDiffLines(), nil)
+	m.ToggleMode()
+
+	m.cursor = 2 // removed line
+	m.MoveDown()
+	if m.cursor != 4 {
+		t.Fatalf("cursor = %d, want 4 to skip added line on same display row", m.cursor)
+	}
+}
+
+func TestDiffView_SplitMoveUpSkipsSharedDisplayRow(t *testing.T) {
+	m := NewDiffViewModel()
+	m.SetSize(80, 20)
+	m.SetContent(testDiffLines(), nil)
+	m.ToggleMode()
+
+	m.cursor = 3 // added line
+	m.MoveUp()
+	if m.cursor != 1 {
+		t.Fatalf("cursor = %d, want 1 to skip removed line on same display row", m.cursor)
+	}
+}
+
 func TestDiffView_ToggleMode_ClampsScroll(t *testing.T) {
 	m := NewDiffViewModel()
 	m.SetSize(80, 3)

--- a/internal/tui/diffview_test.go
+++ b/internal/tui/diffview_test.go
@@ -511,6 +511,32 @@ func TestDiffView_SplitMoveUpSkipsSharedDisplayRow(t *testing.T) {
 	}
 }
 
+func TestDiffView_SplitMoveDownSkipsMultiLineSharedRows(t *testing.T) {
+	m := NewDiffViewModel()
+	m.SetSize(80, 20)
+	m.SetContent(testDiffLinesMultipleChanges(), nil)
+	m.ToggleMode()
+
+	m.cursor = 3 // second removed line
+	m.MoveDown()
+	if m.cursor != 6 {
+		t.Fatalf("cursor = %d, want 6 to move to next visual row after shared block", m.cursor)
+	}
+}
+
+func TestDiffView_SplitMoveUpSkipsMultiLineSharedRows(t *testing.T) {
+	m := NewDiffViewModel()
+	m.SetSize(80, 20)
+	m.SetContent(testDiffLinesMultipleChanges(), nil)
+	m.ToggleMode()
+
+	m.cursor = 4 // first added line
+	m.MoveUp()
+	if m.cursor != 1 {
+		t.Fatalf("cursor = %d, want 1 to move to previous visual row before shared block", m.cursor)
+	}
+}
+
 func TestDiffView_ToggleMode_ClampsScroll(t *testing.T) {
 	m := NewDiffViewModel()
 	m.SetSize(80, 3)


### PR DESCRIPTION
## Summary
- move the split diff cursor by display row instead of raw diff line when adjacent lines share one split row
- avoid landing twice on the same visual row for removed/added pairs
- add regression tests for moving up and down across shared split rows

## Verification
- go test ./...
- go run . --fixture wide-split
